### PR TITLE
Add github workflows for release and validation

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -1,0 +1,19 @@
+name: Validate with hassfest
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    name: Hassfest Validation
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Hassfest validation
+        uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Validate version consistency
+        run: |
+          # Extract version from tag (remove 'v' prefix)
+          TAG_VERSION=${GITHUB_REF_NAME#v}
+          
+          # Extract version from manifest.json
+          MANIFEST_VERSION=$(grep -Po '"version"\s*:\s*"\K[^"]+' custom_components/leviosa_shades/manifest.json)
+          
+          echo "Tag version: $TAG_VERSION"
+          echo "Manifest version: $MANIFEST_VERSION"
+          
+          # Check if versions match
+          if [ "$TAG_VERSION" != "$MANIFEST_VERSION" ]; then
+            echo "Error: Tag version ($TAG_VERSION) does not match manifest.json version ($MANIFEST_VERSION)"
+            echo "Please ensure the version in manifest.json matches the tag before creating a release."
+            exit 1
+          fi
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
+          name: Release ${{ github.ref_name }}
+          body: |
+            ## Leviosa Motor Shades ${{ github.ref_name }}
+            
+            ### Installation
+            
+            #### Via HACS (Recommended)
+            Add this repository as a custom repository in HACS and install "Leviosa Motor Shades"
+            
+            #### Manual Installation
+            Download the `leviosa_shades` folder and place it in your `custom_components` directory.
+            
+            ### What's Changed
+            See the auto-generated release notes below for details.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,24 @@
+name: Validate
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  validate-hacs:
+    runs-on: ubuntu-latest
+    name: HACS Validation
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration
+          ignore: brands

--- a/README.md
+++ b/README.md
@@ -45,3 +45,20 @@ Restart Home Assistant after installation.
 
 Add the Leviosa integration through "Devices & services" under "Settings" in 
 Home Assistant
+
+## Development
+
+### Version Management
+
+When creating a new release:
+
+1. Update the version in `custom_components/leviosa_shades/manifest.json`
+2. Commit the version change: `git commit -am "Bump version to X.Y.Z"`
+3. Create a git tag matching the version: `git tag vX.Y.Z`
+4. Push the changes and tag: `git push && git push --tags`
+
+The GitHub Actions workflow will automatically create a release when a version tag is pushed. 
+HACS uses GitHub releases to notify users of updates, so it's important that:
+- The version in `manifest.json` matches the git tag
+- Releases follow semantic versioning (X.Y.Z format)
+- Pre-release versions can include suffixes like `-beta` or `-rc`

--- a/README.md
+++ b/README.md
@@ -1,11 +1,34 @@
 # Leviosa WiFi Zone Bridge Integration for Home Assistant
 
+[![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=radusuciu&repository=LeviosaBridgeHomeAssistant&category=integration)
+
 This integration uses [Leviosa's](https://leviosashades.com)
 original Home Assistant [custom component implementation](https://leviosashades.com/pages/beta-testing-for-home-assistant) 
 to make Leviosa's WiFi Zone bridge and associated shades available for use 
 with Home Assistant.
 
 ## Installation
+
+### Option 1: Install via HACS (Recommended)
+
+1. Make sure you have [HACS](https://hacs.xyz/) installed
+2. Click the button below to add this repository to HACS:
+
+   [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=radusuciu&repository=LeviosaBridgeHomeAssistant&category=integration)
+   
+   Or manually add it:
+   - In HACS, click on "Integrations"
+   - Click the three dots menu in the top right corner
+   - Select "Custom repositories"
+   - Add `https://github.com/radusuciu/LeviosaBridgeHomeAssistant` as an Integration
+   - Click "Add"
+
+3. Search for "Leviosa Motor Shades" in HACS and install it
+4. Restart Home Assistant
+5. Add the Leviosa integration through "Devices & services" under "Settings"
+
+### Option 2: Manual Installation
 
 This component is an _integration_, which is different from an _add on_.
 Integrations are managed through the "Devices & Services" configuration menu

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Leviosa WiFi Zone Bridge Integration for Home Assistant
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=radusuciu&repository=LeviosaBridgeHomeAssistant&category=integration)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=alfredcrager&repository=LeviosaBridgeHomeAssistant&category=integration)
 
 This integration uses [Leviosa's](https://leviosashades.com)
 original Home Assistant [custom component implementation](https://leviosashades.com/pages/beta-testing-for-home-assistant) 
@@ -15,13 +15,13 @@ with Home Assistant.
 1. Make sure you have [HACS](https://hacs.xyz/) installed
 2. Click the button below to add this repository to HACS:
 
-   [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=radusuciu&repository=LeviosaBridgeHomeAssistant&category=integration)
+   [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=alfredcrager&repository=LeviosaBridgeHomeAssistant&category=integration)
    
    Or manually add it:
    - In HACS, click on "Integrations"
    - Click the three dots menu in the top right corner
    - Select "Custom repositories"
-   - Add `https://github.com/radusuciu/LeviosaBridgeHomeAssistant` as an Integration
+   - Add `https://github.com/alfredcrager/LeviosaBridgeHomeAssistant` as an Integration
    - Click "Add"
 
 3. Search for "Leviosa Motor Shades" in HACS and install it

--- a/custom_components/leviosa_shades/__init__.py
+++ b/custom_components/leviosa_shades/__init__.py
@@ -5,10 +5,14 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.const import Platform
+from homeassistant.helpers import config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.COVER]
+
+# This integration is configured via config flow only
+CONFIG_SCHEMA = cv.config_entry_only_config_schema("leviosa_shades")
 
 
 async def async_setup(hass: HomeAssistant, config: dict):

--- a/custom_components/leviosa_shades/manifest.json
+++ b/custom_components/leviosa_shades/manifest.json
@@ -2,7 +2,8 @@
   "domain": "leviosa_shades",
   "name": "Leviosa Motor Shades",
   "documentation": "https://www.home-assistant.io/integrations/leviosa_shades",
-  "version":"2.0.1",
+  "issue_tracker": "https://github.com/radusuciu/LeviosaBridgeHomeAssistant/issues",
+  "version":"2.0.2",
   "codeowners": ["@altersis"],
   "dependencies": ["cover"],
   "config_flow": true

--- a/custom_components/leviosa_shades/manifest.json
+++ b/custom_components/leviosa_shades/manifest.json
@@ -1,8 +1,9 @@
 {
   "domain": "leviosa_shades",
   "name": "Leviosa Motor Shades",
-  "documentation": "https://www.home-assistant.io/integrations/leviosa_shades",
+  "documentation": "https://github.com/radusuciu/LeviosaBridgeHomeAssistant",
   "issue_tracker": "https://github.com/radusuciu/LeviosaBridgeHomeAssistant/issues",
+  "iot_class": "local_polling",
   "version":"2.0.2",
   "codeowners": ["@altersis"],
   "dependencies": ["cover"],

--- a/custom_components/leviosa_shades/manifest.json
+++ b/custom_components/leviosa_shades/manifest.json
@@ -4,8 +4,8 @@
   "codeowners": ["@altersis"],
   "config_flow": true,
   "dependencies": ["cover"],
-  "documentation": "https://github.com/radusuciu/LeviosaBridgeHomeAssistant",
+  "documentation": "https://github.com/alfredcrager/LeviosaBridgeHomeAssistant",
   "iot_class": "local_polling",
-  "issue_tracker": "https://github.com/radusuciu/LeviosaBridgeHomeAssistant/issues",
+  "issue_tracker": "https://github.com/alfredcrager/LeviosaBridgeHomeAssistant/issues",
   "version": "2.0.2"
 }

--- a/custom_components/leviosa_shades/manifest.json
+++ b/custom_components/leviosa_shades/manifest.json
@@ -1,11 +1,11 @@
 {
   "domain": "leviosa_shades",
   "name": "Leviosa Motor Shades",
-  "documentation": "https://github.com/radusuciu/LeviosaBridgeHomeAssistant",
-  "issue_tracker": "https://github.com/radusuciu/LeviosaBridgeHomeAssistant/issues",
-  "iot_class": "local_polling",
-  "version":"2.0.2",
   "codeowners": ["@altersis"],
+  "config_flow": true,
   "dependencies": ["cover"],
-  "config_flow": true
+  "documentation": "https://github.com/radusuciu/LeviosaBridgeHomeAssistant",
+  "iot_class": "local_polling",
+  "issue_tracker": "https://github.com/radusuciu/LeviosaBridgeHomeAssistant/issues",
+  "version": "2.0.2"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,4 @@
+{
+  "name": "Leviosa Motor Shades",
+  "render_readme": true
+}


### PR DESCRIPTION
To pass HACS validation you'll also need to add topics to the github repository. I used: home-assistant hacs smart-blinds home-assistant-integration leviosa leviosa-zone

Created as a draft since I didn't spend too much time on this (largely Claude Code authored).